### PR TITLE
bump osc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "lodash": "~3.10.1",
-    "osc": "~2.0.3",
+    "osc": "~2.2.0",
     "ws": "~0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi @nomve,

can you merge this, please? 

Bump osc version, otherwise you'll get in error during ```npm install``` while using node v8 lts.

Thanks to @dmdrmc, for providing this fix.

Cheers
Tobi